### PR TITLE
Linuxfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -flto -ffunction-sections -fdata-sections")
-set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--gc-sections -flto")
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections -flto -s")  # -s = strip
-
 # QtCreator supports the following variables for Android, which are identical to qmake Android variables.
 # Check https://doc.qt.io/qt/deployment-android.html for more information.
 # They need to be set before the find_package( ...) calls below.
@@ -29,9 +25,17 @@ set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections -flto -s")  # -s = strip
 #endif()
 
 find_package(QT NAMES Qt6 Qt5 COMPONENTS Widgets REQUIRED)
+if(LINUX)
+    include(GNUInstallDirs)
+    if(POLICY CMP0072)
+        cmake_policy(SET CMP0072 NEW)
+        set(OpenGL_GL_PREFERENCE GLVND)
+    endif()
+    find_package(OpenGL REQUIRED)
+endif()
+
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Sql REQUIRED)
-
 set(PROJECT_SOURCES
         main.cpp
         showjcr.cpp
@@ -67,7 +71,17 @@ else()
         )
     endif()
 endif()
-
+if(LINUX)
+    find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core DBus)
+    target_link_libraries(ShowJCR PRIVATE Qt${QT_VERSION_MAJOR}::DBus)
+    set_target_properties(ShowJCR PROPERTIES OUTPUT_NAME "showjcr")
+    install(TARGETS ShowJCR
+            RUNTIME
+        )
+    install(FILES 中科院分区表及JCR原始数据文件/jcr.db DESTINATION ${CMAKE_INSTALL_DATADIR}/ShowJCR)
+    install(FILES resources/io.hitfyd.ShowJCR.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+    install(FILES resources/image/jcr-logo.jpg DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps RENAME io.hitfyd.ShowJCR.jpg)
+endif()
 target_link_libraries(ShowJCR PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 target_link_libraries(ShowJCR PRIVATE Qt${QT_VERSION_MAJOR}::Sql)
 

--- a/main.cpp
+++ b/main.cpp
@@ -7,7 +7,11 @@
 #include <QDateTime>
 #include <QFile>
 #include <QDir>
-
+#ifdef Q_OS_LINUX
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#endif
 void outputMessage(QtMsgType type, const QMessageLogContext &context, const QString &msg)
  {
      QString text;
@@ -50,7 +54,11 @@ void outputMessage(QtMsgType type, const QMessageLogContext &context, const QStr
      static QString logName = QApplication::applicationName() + "_log.txt";
      mutex.lock();
      QFile file(QDir::temp().absoluteFilePath(logName));    //日志文件写在temp目录
-     file.open(QIODevice::WriteOnly | QIODevice::Append);
+		 if (!file.open(QIODevice::WriteOnly | QIODevice::Append)) {
+				 qDebug() << "无法打开文件:" << file.errorString();
+				 return;
+		 }
+		 //消除警告 需要返回值
      QTextStream text_stream(&file);
      text_stream << message << "\r\n";
      file.flush();
@@ -65,13 +73,26 @@ int main(int argc, char *argv[])
     //注册日志函数
     qInstallMessageHandler(outputMessage);
     //设置程序单启动，使用共享内存创建的同时设置key,也可以setKey
-    QSharedMemory sm(QApplication::applicationName());
-    if(sm.attach()){
-        qWarning() << "SingleApp is running!" << __FUNCTION__;
-        QMessageBox::warning(QApplication::activeWindow(), "程序正在运行", "程序已经启动，请不要重复运行！请检查任务栏或系统托盘！");
-        return 0;
+		#ifdef Q_OS_WIN
+		QSharedMemory sm(QApplication::applicationName());
+		if(sm.attach()){
+				qWarning() << "SingleApp is running!" << __FUNCTION__;
+				QMessageBox::warning(QApplication::activeWindow(), "程序正在运行", "程序已经启动，请不要重复运行！请检查任务栏或系统托盘！");
+				return 0;
+		}
+		sm.create(1);
+		#endif
+		//linux 使用dbus注册服务 名称为反向域名法
+		#ifdef Q_OS_LINUX
+		a.setApplicationName("ShowJCR");
+    const QString serviceName = "io.hitfyd.ShowJCR";
+    if (!QDBusConnection::sessionBus().registerService(serviceName)) {
+				//注册失败自动触发
+				qWarning() << "SingleApp is running!" << __FUNCTION__;
+				QMessageBox::warning(QApplication::activeWindow(), "程序正在运行", "程序已经启动，请不要重复运行！请检查任务栏或系统托盘！");
+				return 0;
     }
-    sm.create(1);
+		#endif
     ShowJCR w;
     //如果有命令行参数而且参数是开机自启动
     if (argc > 1 && (argv[1] == QString("autoStart"))){//注意参数没有空格

--- a/resources/io.hitfyd.ShowJCR.desktop
+++ b/resources/io.hitfyd.ShowJCR.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Name=ShowJCR
+GenericName=ShowJCR
+Comment[zh_CN]=查询期刊分区
+Exec=showjcr
+Icon=io.hitfyd.ShowJCR
+Type=Application
+StartupNotify=true
+Categories=Utility;
+Terminal=false
+X-GNOME-Autostart-enabled=true
+Keywords=ShowJCR;
+Keywords[zh_CN]=期刊;中科院;分区;查询;搜索;

--- a/showjcr.cpp
+++ b/showjcr.cpp
@@ -7,12 +7,19 @@
 #include <QCompleter>
 #include <QMimeData>
 #include <QMenu>
+#ifdef Q_OS_LINUX
+#include <QStandardPaths>
+#endif
 
 const QString ShowJCR::author = "hitfyd";
 const QString ShowJCR::version = "v2026-1.2";
 const QString ShowJCR::email = "hitfyd@foxmail.com";
 const QString ShowJCR::codeURL = "https://github.com/hitfyd/ShowJCR";
+#ifndef Q_OS_LINUX
 const QString ShowJCR::updateURL = "https://github.com/hitfyd/ShowJCR/releases";
+#elifdef Q_OS_LINUX
+const QString ShowJCR::updateURL = "";//我不觉得会有人会发布linux版本
+#endif
 const QString ShowJCR::windowTitile = tr("分区表2026");
 const QString ShowJCR::logoIconName = ":/image/jcr-logo.jpg";
 const QString ShowJCR::datasetName = "jcr.db";  //数据集暂时无法使用资源文件；在程序自启动时，程序的运行目录是C:/WINDOWS/system32而不是程序目录，因此需要结合QApplication::applicationFilePath()修改
@@ -27,7 +34,23 @@ ShowJCR::ShowJCR(QWidget *parent)
 
     //获取程序运行信息
     appName = QApplication::applicationName();//程序名称
+		#ifndef Q_OS_LINUX
     appDir = QDir(QApplication::applicationDirPath());//程序目录（QDir类型）
+		#endif
+		#ifdef Q_OS_LINUX
+		//通过循环读取列表来搜索jcr.db
+		QStringList locations = QStandardPaths::standardLocations(QStandardPaths::AppDataLocation);
+		for (const QString &path : locations) {
+				if (path.isEmpty()) continue;
+				QDir dir(path);
+				QString fullPath = dir.filePath(ShowJCR::datasetName);
+				if (QFileInfo::exists(fullPath)) {
+						appDir = path;
+						break; // 找到后通常应该跳出循环
+				}
+		}
+		#endif
+
     appPath = QApplication::applicationFilePath();// 程序路径
 
     qDebug() << "start check:" << appName << appDir.path() << appPath;
@@ -195,6 +218,7 @@ void ShowJCR::updateGUI()
 
 void ShowJCR::setAutoStart()
 {
+	#ifdef Q_OS_WIN
     QString nativeAppPath = QDir::toNativeSeparators(appPath);
     QString autoStartValue = nativeAppPath + " autoStart";//便于判断程序是否为自启动，注意参数前面有空格
     QString regPath = "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";//无需管理员权限，写入当前用户注册表
@@ -206,6 +230,31 @@ void ShowJCR::setAutoStart()
     else if(val == autoStartValue & !autoStart){//移除自启动
         reg.remove(appName);
     }
+	#elifdef Q_OS_LINUX
+	//通过循环读取列表来搜索desktop
+		QString sourceFile;
+		QStringList locations = QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
+			for (const QString &path : locations) {
+					QDir dir(path);
+					QString fullPath = dir.filePath("io.hitfyd.ShowJCR.desktop");
+					if (QFileInfo::exists(fullPath)) {
+							sourceFile=fullPath; // 找到文件，返回路径
+					}
+			}
+		QString configDir = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+		QDir autostartDir(configDir + "autostart");
+		if (!autostartDir.exists()) {
+			if (!autostartDir.mkpath(".")) {
+					return;
+				}
+		}
+		QString desktopFilePath = autostartDir.filePath("io.hitfyd.ShowJCR.desktop");
+		if (QFile::exists(desktopFilePath)){
+				QFile::remove(desktopFilePath);
+			}else{
+				QFile::copy(sourceFile, desktopFilePath);
+			}
+	#endif
 }
 
 void ShowJCR::closeEvent(QCloseEvent *event)


### PR DESCRIPTION
fix https://github.com/hitfyd/ShowJCR/issues/16#issue-4875883252
第一个问题数据库 db 必须是在app目录的linux 修复 
基于cmake install 安装上去/系统方法 ，使用xdg目录
第二个基于 dbus接口实现唯一启动 而不是linux上不稳定的内存共享
修改 linux下输出小写二进制 linux上程序大部分都是小写，由于linux严格区分大小写，shift很麻烦。
CMAKE_CXX_FLAGS_RELEASE 这些FLAGS 为什么在cmake文件赋予
在rpmbuild 会使用 %set_build_flags 赋予flags 不确定是否会冲突
测试系统 ： openSUSE Tumbleweed 20260710
KDE Plasma 版本： 6.7.2
KDE 程序框架版本： 6.27.0
Qt 版本： 6.11.1
内核版本： 7.1.3-1-default (64 位)
图形平台： Wayland